### PR TITLE
Fix topic link color in dark mode

### DIFF
--- a/common/color_definitions.scss
+++ b/common/color_definitions.scss
@@ -1,0 +1,5 @@
+$simple-theme-link-color: dark-light-choose(#3b5998, $primary);
+
+:root {
+  --simple-theme-link-color: #{$simple-theme-link-color};
+}

--- a/common/color_definitions.scss
+++ b/common/color_definitions.scss
@@ -1,4 +1,4 @@
-$simple-theme-link-color: dark-light-choose(#3b5998, $primary);
+$simple-theme-link-color: dark-light-choose(#3b5998, #7e97cd);
 
 :root {
   --simple-theme-link-color: #{$simple-theme-link-color};

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -7,7 +7,7 @@
 }
 
 .topic-list a.title:not(.badge-notification) {
-  color: #3b5998;
+  color: var(--simple-theme-link-color);
   font-weight: normal;
   font-family: "Helvetica Neue", Helvetica, Arial, Utkal, sans-serif;
   font-size: 18px;


### PR DESCRIPTION
As shown [here](https://meta.discourse.org/t/sams-personal-minimal-topic-list-design/23552/335?u=alex_p), dark blue link color is not very readable on dark background.

So this PR adds a custom property in `color_definitions` switching to the color scheme primary color when in dark mode.

We should keep the original color in light mode because it was one of the features of this theme.