### PR TITLE
FIX: Add back missing translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,6 @@
 en:
   theme_metadata:
     description: "Simplified front page design with classic colors and typography"
+  replies: "Replies"
+  last_post: "Last Post"
+  likes: "Likes"


### PR DESCRIPTION
Followup 62ca1494bd68c2a40eaac1603aa59412d6057792,
I accidentally deleted other theme translations
