### PR TITLE
FIX: only apply templates to desktop

### DIFF
--- a/javascripts/discourse/connectors/topic-list-after-columns/latest-poster-column.hbr
+++ b/javascripts/discourse/connectors/topic-list-after-columns/latest-poster-column.hbr
@@ -1,13 +1,15 @@
-<td class="last-post topic-list-data">
-  <div class="last-post__contents">
-    <div class='poster-avatar'>
-      <a href="{{context.topic.lastPostUrl}}" data-user-card="{{context.topic.last_poster_username}}">{{avatar context.topic.lastPosterUser imageSize="medium"}}</a>
+{{#if context.site.desktopView}}
+  <td class="last-post topic-list-data">
+    <div class="last-post__contents">
+      <div class='poster-avatar'>
+        <a href="{{context.topic.lastPostUrl}}" data-user-card="{{context.topic.last_poster_username}}">{{avatar context.topic.lastPosterUser imageSize="medium"}}</a>
+      </div>
+      <div class='poster-info'>
+        <a href="{{context.topic.lastPostUrl}}">
+          {{format-date context.topic.bumpedAt format="tiny"}}
+        </a>
+        <span class='editor'><a href="/u/{{context.topic.last_poster_username}}" data-auto-route="true" data-user-card="{{topic.last_poster_username}}">{{context.topic.last_poster_username}}</a></span>
+      </div>
     </div>
-    <div class='poster-info'>
-      <a href="{{context.topic.lastPostUrl}}">
-        {{format-date context.topic.bumpedAt format="tiny"}}
-      </a>
-      <span class='editor'><a href="/u/{{context.topic.last_poster_username}}" data-auto-route="true" data-user-card="{{topic.last_poster_username}}">{{context.topic.last_poster_username}}</a></span>
-    </div>
-  </div>
-</td>
+  </td>
+{{/if}}

--- a/javascripts/discourse/connectors/topic-list-before-status/original-post-date.hbr
+++ b/javascripts/discourse/connectors/topic-list-before-status/original-post-date.hbr
@@ -1,3 +1,5 @@
+{{#if context.site.desktopView}}
    {{~#if context.topic.creator ~}}
       <span class="op-data"><a href="/u/{{context.topic.creator.username}}" data-auto-route="true" data-user-card="{{context.topic.creator.username}}">{{context.topic.creator.username}}</a> <a class="op-date" href={{topic.url}}>{{format-date context.topic.createdAt format="tiny"}}</a></span>
-    {{~/if ~}}
+   {{~/if ~}}
+{{/if}}

--- a/javascripts/discourse/connectors/topic-list-header-after/latest-poster-column-header.hbr
+++ b/javascripts/discourse/connectors/topic-list-header-after/latest-poster-column-header.hbr
@@ -1,1 +1,3 @@
-{{raw "topic-list-header-column" order='last-post' name='user.last_posted'}}
+{{#if context.site.desktopView}}
+  {{raw "topic-list-header-column" order='last-post' name='user.last_posted'}}
+{{/if}}


### PR DESCRIPTION
Follow up to 914f969, these should only apply to desktop


before:
![image](https://github.com/user-attachments/assets/b63798e5-6b3c-481e-b79f-cde2153d12e4)


after:
![image](https://github.com/user-attachments/assets/f68aea1b-04f2-401c-af93-ff18aede08b1)

