### PR TITLE
UX: remove zebra striping

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -59,10 +59,6 @@
     }
   }
 
-  .topic-list-body .topic-list-item:nth-child(even) {
-    background-color: var(--primary-very-low);
-  }
-
   .topic-list-item {
     .link-bottom-line {
       .excerpt {


### PR DESCRIPTION
Misinterpreted some old broken CSS as *adding* zebra striping, but it was actually so old it was *removing* it from when it was the default in Discourse (only realized this when re–reading the Meta topic for the theme)

Before:
![image](https://github.com/user-attachments/assets/25796fd7-f4ef-4219-9268-538b74f9c361)


After:
![image](https://github.com/user-attachments/assets/c7542061-af19-41cc-b8d9-c392360596d4)
