### PR TITLE
Don't manually force `--font-family` in desktop.scss

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,7 +1,3 @@
-:root {
-  --font-family: "Helvetica Neue", Helvetica, Arial, Utkal, sans-serif;
-}
-
 .topic-list {
   tbody {
     border: none;


### PR DESCRIPTION
The theme should obey the font style configured in the Discourse instance's settings and not override it.