### PR TITLE
UX: sameline metadata, fix new badge wrap

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -93,7 +93,6 @@
   }
 
   .main-link a.title {
-    display: inline-block;
     line-height: var(--line-height-medium);
     padding: 0;
     margin-top: 0.15em;
@@ -105,7 +104,6 @@
 
   .discourse-tags {
     align-self: end;
-    margin-left: 0.5em;
     .discourse-tag {
       color: var(--primary-medium);
     }
@@ -118,18 +116,16 @@
   .link-bottom-line {
     font-size: var(--font-down-2);
     margin-top: 0.25em;
+    gap: 0 0.5em;
   }
 
   .op-data {
     display: flex;
-    width: 100%;
-    font-size: var(--font-down-3);
-    align-self: end;
+    font-size: var(--font-down-1);
+    align-self: baseline;
+    gap: 0.25em 0.5em;
     a {
       color: var(--primary-medium);
-    }
-    .op-date {
-      margin-left: 0.5em;
     }
   }
 

--- a/javascripts/discourse/connectors/topic-list-topic-cell-link-bottom-line__before/original-post-date.gjs
+++ b/javascripts/discourse/connectors/topic-list-topic-cell-link-bottom-line__before/original-post-date.gjs
@@ -9,7 +9,6 @@ export default class OriginalPostDate extends Component {
     {{~#if this.site.desktopView~}}
       {{~#if @outletArgs.topic.creator~}}
         <span class="op-data">
-          {{~! no whitespace ~}}
           <a
             href="/u/{{@outletArgs.topic.creator.username}}"
             data-auto-route="true"
@@ -18,7 +17,6 @@ export default class OriginalPostDate extends Component {
           <a class="op-date" href={{@outletArgs.topic.url}}>
             {{formatDate @outletArgs.topic.createdAt format="tiny"}}
           </a>
-          {{~! no whitespace ~}}
         </span>
       {{~/if~}}
     {{~/if~}}


### PR DESCRIPTION
Changed a bit too much in 914f969, this gets us closer to the previous layout with all the metadata in a single line... and also fixes some odd new badge wrapping 

before
![image](https://github.com/user-attachments/assets/94b3ec4a-5eff-47a0-a96b-894fad040c2a)


after
![image](https://github.com/user-attachments/assets/c2d4edba-8646-46c5-bc38-5a81ff1a9aef)
